### PR TITLE
Support `([234]-)?([ASC]-)?RightMouse/LeftMouse`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -751,8 +751,8 @@ module.exports = grammar({
           /([kK]|([SsCc]-))?[Dd][oO][wW][nN]/, // [k|S-|C-]Down
           /([kK]|([SsCc]-))?[Ll][eE][fF][tT]/, // [k|S-|C-]Left
           /([kK]|([SsCc]-))?[Rr][iI][gG][hH][tT]/, // [k|S-|C-]Right
-          /([SsCc]-)?[Ll][eE][fF][tT][Mm][oO][uU][sS][eE]/, // <S|C>-LeftMouse
-          /([SsCc]-)?[Rr][iI][gG][hH][tT][Mm][oO][uU][sS][eE]/, // <S|C>-RightMouse
+          /([234]-)?([AaSsCc]-)?[Ll][eE][fF][tT][Mm][oO][uU][sS][eE]/, // <S|C|A>-LeftMouse
+          /([234]-)?([AaSsCc]-)?[Rr][iI][gG][hH][tT][Mm][oO][uU][sS][eE]/, // <S|C|A>-RightMouse
           /([Ss]-)?[Ff][0-9]{1,2}/, // [S-]F<1-12>
           /[Hh][eE][lL][pP]/, // Help
           /[Uu][nN][dD][oO]/, // Undo

--- a/grammar.js
+++ b/grammar.js
@@ -751,8 +751,8 @@ module.exports = grammar({
           /([kK]|([SsCc]-))?[Dd][oO][wW][nN]/, // [k|S-|C-]Down
           /([kK]|([SsCc]-))?[Ll][eE][fF][tT]/, // [k|S-|C-]Left
           /([kK]|([SsCc]-))?[Rr][iI][gG][hH][tT]/, // [k|S-|C-]Right
-          /([234]-)?([AaSsCc]-)?[Ll][eE][fF][tT][Mm][oO][uU][sS][eE]/, // <S|C|A>-LeftMouse
-          /([234]-)?([AaSsCc]-)?[Rr][iI][gG][hH][tT][Mm][oO][uU][sS][eE]/, // <S|C|A>-RightMouse
+          /([234]-)?([SsCc]-)?[Ll][eE][fF][tT][Mm][oO][uU][sS][eE]/, // <S|C>-LeftMouse
+          /([234]-)?([SsCc]-)?[Rr][iI][gG][hH][tT][Mm][oO][uU][sS][eE]/, // <S|C>-RightMouse
           /([Ss]-)?[Ff][0-9]{1,2}/, // [S-]F<1-12>
           /[Hh][eE][lL][pP]/, // Help
           /[Uu][nN][dD][oO]/, // Undo

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4972,14 +4972,14 @@
           "type": "IMMEDIATE_TOKEN",
           "content": {
             "type": "PATTERN",
-            "value": "([SsCc]-)?[Ll][eE][fF][tT][Mm][oO][uU][sS][eE]"
+            "value": "([234]-)?([AaSsCc]-)?[Ll][eE][fF][tT][Mm][oO][uU][sS][eE]"
           }
         },
         {
           "type": "IMMEDIATE_TOKEN",
           "content": {
             "type": "PATTERN",
-            "value": "([SsCc]-)?[Rr][iI][gG][hH][tT][Mm][oO][uU][sS][eE]"
+            "value": "([234]-)?([AaSsCc]-)?[Rr][iI][gG][hH][tT][Mm][oO][uU][sS][eE]"
           }
         },
         {
@@ -14123,4 +14123,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4972,14 +4972,14 @@
           "type": "IMMEDIATE_TOKEN",
           "content": {
             "type": "PATTERN",
-            "value": "([234]-)?([AaSsCc]-)?[Ll][eE][fF][tT][Mm][oO][uU][sS][eE]"
+            "value": "([234]-)?([SsCc]-)?[Ll][eE][fF][tT][Mm][oO][uU][sS][eE]"
           }
         },
         {
           "type": "IMMEDIATE_TOKEN",
           "content": {
             "type": "PATTERN",
-            "value": "([234]-)?([AaSsCc]-)?[Rr][iI][gG][hH][tT][Mm][oO][uU][sS][eE]"
+            "value": "([234]-)?([SsCc]-)?[Rr][iI][gG][hH][tT][Mm][oO][uU][sS][eE]"
           }
         },
         {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -130,9 +129,16 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -166,7 +172,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +182,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +190,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}


### PR DESCRIPTION
Adds support for double, triple, and quadruple click. Current, adding the number before the click leads to incorrect highlighting.

nvim version: 
```
NVIM v0.10.0-dev-2355+g1c7b0b9d5
Build type: RelWithDebInfo
LuaJIT 2.1.1707061634
Run "nvim -V1 -v" for more info
```

Note: I couldn't figure out how to test this locally on the latest neovim nightly, so I haven't been able to verify locally that this works. Tried adding `vim.opt.runtimepath:append('PATH/tree-sitter-vim')` to my lua config, but it didn't seem to override the default. As a next step either way, it could be helpful to include instructions for how we can override the default parser that's included with nightly.

![image](https://github.com/neovim/tree-sitter-vim/assets/3723671/19f2f464-07e8-42d1-a863-12bf2e2432e7)
