### PR TITLE
feat(luaeq): add the equal sign command

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -307,7 +307,11 @@ module.exports = grammar({
     colorscheme_statement: ($) =>
       command($, "colorscheme", optional(alias($.filename, $.name))),
 
-    lua_statement: ($) => command($, "lua", choice($.chunk, $.script)),
+    lua_statement: ($) =>
+      choice(
+        command($, "lua", choice($.chunk, $.script)),
+        seq("=", choice($.chunk, $.script))
+      ),
     ruby_statement: ($) => command($, "ruby", choice($.chunk, $.script)),
     python_statement: ($) => command($, "python", choice($.chunk, $.script)),
     perl_statement: ($) => command($, "perl", choice($.chunk, $.script)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1907,27 +1907,54 @@
       ]
     },
     "lua_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_lua"
-          },
-          "named": false,
-          "value": "lua"
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "chunk"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_lua"
+              },
+              "named": false,
+              "value": "lua"
             },
             {
-              "type": "SYMBOL",
-              "name": "script"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "chunk"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "script"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "="
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "chunk"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "script"
+                }
+              ]
             }
           ]
         }
@@ -14119,3 +14146,4 @@
   "inline": [],
   "supertypes": []
 }
+

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -129,16 +130,9 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -172,7 +166,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -182,7 +176,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -190,7 +184,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}


### PR DESCRIPTION
I used `seq("=", ...)` because `command("=", ...)` didn't work.
```diff
diff --git a/grammar.js b/grammar.js
index 29f07e4..424fd88 100644
--- a/grammar.js
+++ b/grammar.js
@@ -307,7 +307,11 @@ module.exports = grammar({
     colorscheme_statement: ($) =>
       command($, "colorscheme", optional(alias($.filename, $.name))),
 
-    lua_statement: ($) => command($, "lua", choice($.chunk, $.script)),
+    lua_statement: ($) =>
+      choice(
+        command($, "lua", choice($.chunk, $.script)),
+        command($, "=", choice($.chunk, $.script))
+      ),
     ruby_statement: ($) => command($, "ruby", choice($.chunk, $.script)),
     python_statement: ($) => command($, "python", choice($.chunk, $.script)),
     perl_statement: ($) => command($, "perl", choice($.chunk, $.script)),
diff --git a/keywords.js b/keywords.js
index ff3586f..6ef4e43 100644
--- a/keywords.js
+++ b/keywords.js
@@ -109,6 +109,11 @@ const KEYWORDS = {
     opt: "",
     ignore_comments_after: false,
   },
+  LUAEQ: {
+    mandat: "=",
+    opt: "",
+    ignore_comments_after: false,
+  },
   RUBY: {
     mandat: "rub",
     opt: "y",
```
```vim
= vim.api.nvim_foo_bar
```
```fennel
(script_file [0, 0] - [1, 0]
  (ERROR [0, 0] - [0, 22]
    (marker_definition [0, 6] - [0, 22])))
main.vim        0 ms    (ERROR [0, 0] - [0, 22])
```