### PR TITLE
Add `file-types` to tree-sitter.json

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -4,6 +4,7 @@
       "name": "vim",
       "path": ".",
       "scope": "text.vim",
+      "file-types": [ "vim" ],
       "highlights": "queries/vim/highlights.scm",
       "injections": "queries/vim/injections.scm"
     }


### PR DESCRIPTION
Or else it will write this weird message during `tree-sitter test`

```
syntax highlighting:
No language found for path `/home/perchun/tree-sitter-vim/test/highlight/command_modifiers.vim`

If a language should be associated with this file extension, please ensure the path to `/home/perchun/tree-sitter-vim/test/highlight/command_modifiers.vim` is inside one of the following directories as specified by your 'config.json':

  1. /home/perchun/github  
  2. /home/perchun/src  
  3. /home/perchun/source  
  4. /home/perchun/projects  
  5. /home/perchun/dev  
  6. /home/perchun/git

If the directory that contains the relevant grammar for `/home/perchun/tree-sitter-vim/test/highlight/command_modifiers.vim` is not listed above, please add the directory to the list of directories in your config file, located at /home/perchun/.config/tree-sitter/config.json
```