### PR TITLE
fix(scanner): remove `iswpunct`

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -324,7 +324,7 @@ bool tree_sitter_vim_external_scanner_scan(void *payload, TSLexer *lexer,
   }
 
   // Not sure about the punctuation here...
-  if (valid_symbols[SEP_FIRST] && iswpunct(lexer->lookahead)) {
+  if (valid_symbols[SEP_FIRST]) {
     s->separator = lexer->lookahead;
     advance(lexer, false);
     s->ignore_comments = true;


### PR DESCRIPTION
not supported in WASM

DO NOT MERGE; just a test to see what CI thinks about this (tests and fuzz pass locally).

Corpus parse shows significant regressions (as expected); I'm leaving this up mostly as a reminder that we need to remove this, one way or another.