### PR TITLE
feat(grammar): support "trim" for script heredocs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -325,6 +325,7 @@ module.exports = grammar({
     script: ($) =>
       seq(
         "<<",
+        optional(alias("trim", $.parameter)),
         choice(alias($._script_heredoc_marker, $.marker_definition), "\n"),
         alias(repeat($._heredoc_line), $.body),
         alias($._heredoc_end, $.endmarker)

--- a/queries/vim/highlights.scm
+++ b/queries/vim/highlights.scm
@@ -253,6 +253,9 @@
 (heredoc
   (parameter) @keyword)
 
+(script
+  (parameter) @keyword)
+
 [
   (marker_definition)
   (endmarker)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2088,6 +2088,23 @@
             {
               "type": "ALIAS",
               "content": {
+                "type": "STRING",
+                "value": "trim"
+              },
+              "named": true,
+              "value": "parameter"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "SYMBOL",
                 "name": "_script_heredoc_marker"
               },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7112,6 +7112,10 @@
         {
           "type": "marker_definition",
           "named": true
+        },
+        {
+          "type": "parameter",
+          "named": true
         }
       ]
     }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -129,18 +129,18 @@ static bool check_prefix(TSLexer *lexer, char *prefix, unsigned int prefix_len,
   return true;
 }
 
-static bool try_lex_heredoc_marker(Scanner *scanner, TSLexer *lexer, const bool is_let_heredoc)
+static bool try_lex_heredoc_marker(Scanner *scanner, TSLexer *lexer)
 {
   char marker[UINT8_MAX] = { '\0' };
   uint16_t marker_len = 0;
 
-  if (iswlower(lexer->lookahead) && is_let_heredoc) {
+  if (iswlower(lexer->lookahead)) {
     return false;
   }
 
   // We should be at the start of the script marker
   // Note that :let-heredocs do not allow for spaces in the endmarker
-  while ((!is_let_heredoc || !IS_SPACE_TABS(lexer->lookahead)) && lexer->lookahead && lexer->lookahead != '\n' && marker_len < HEREDOC_MARKER_LEN) {
+  while ((!IS_SPACE_TABS(lexer->lookahead)) && lexer->lookahead && lexer->lookahead != '\n' && marker_len < HEREDOC_MARKER_LEN) {
     marker[marker_len] = lexer->lookahead;
     marker_len++;
     advance(lexer, false);
@@ -423,11 +423,11 @@ bool tree_sitter_vim_external_scanner_scan(void *payload, TSLexer *lexer,
 
   if (valid_symbols[SCRIPT_HEREDOC_MARKER]) {
     lexer->result_symbol = SCRIPT_HEREDOC_MARKER;
-    return try_lex_heredoc_marker(s, lexer, false);
+    return try_lex_heredoc_marker(s, lexer);
   }
   if (valid_symbols[LET_HEREDOC_MARKER]) {
     lexer->result_symbol = LET_HEREDOC_MARKER;
-    return try_lex_heredoc_marker(s, lexer, true);
+    return try_lex_heredoc_marker(s, lexer);
   }
   if (valid_symbols[HEREDOC_END]) {
     uint8_t marker_len = s->marker_len != 0 ? s->marker_len : 1;

--- a/test/corpus/embedded_langs.txt
+++ b/test/corpus/embedded_langs.txt
@@ -42,6 +42,10 @@ lua <<
 require("nvim-autopairs").setup()
 .
 
+lua << trim EOF
+  vim.api.nvim_command('echo "Trimmed heredoc"')
+EOF
+
 --------------------------------------------------------------------------------
 
 (script_file
@@ -52,6 +56,12 @@ require("nvim-autopairs").setup()
       (endmarker)))
   (lua_statement
     (script
+      (body)
+      (endmarker)))
+  (lua_statement
+    (script
+      (parameter)
+      (marker_definition)
       (body)
       (endmarker))))
 


### PR DESCRIPTION
Allow the optional "trim", as documented in ":help :lua-heredoc".

This removes the need for try_lex_heredoc_marker()'s `is_let_heredoc`
parameter since both script and let heredocs can have a parameter.