### PR TITLE
feat(grammar): support let slice assignments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -488,6 +488,7 @@ module.exports = grammar({
           $.register,
           $.option,
           $.index_expression,
+          $.slice_expression,
           $.field_expression,
           $.list_assignment
         ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3041,6 +3041,10 @@
             },
             {
               "type": "SYMBOL",
+              "name": "slice_expression"
+            },
+            {
+              "type": "SYMBOL",
               "name": "field_expression"
             },
             {

--- a/test/corpus/let_statement.txt
+++ b/test/corpus/let_statement.txt
@@ -119,6 +119,51 @@ let [fleh, b, c] = [1, 2, 3]
       (integer_literal))))
 
 ================================================================================
+Let slice assignment
+================================================================================
+
+let x[: 4] = ["aval", "bval", 1, 2]
+let y[1:] = ['a', 'b']
+let z[:] = [1, 2, 3]
+let a[1:3] = [1, 2, 3]
+
+--------------------------------------------------------------------------------
+
+(script_file
+  (let_statement
+    (slice_expression
+      (identifier)
+      (integer_literal))
+    (list
+      (string_literal)
+      (string_literal)
+      (integer_literal)
+      (integer_literal)))
+  (let_statement
+    (slice_expression
+      (identifier)
+      (integer_literal))
+    (list
+      (string_literal)
+      (string_literal)))
+  (let_statement
+    (slice_expression
+      (identifier))
+    (list
+      (integer_literal)
+      (integer_literal)
+      (integer_literal)))
+  (let_statement
+    (slice_expression
+      (identifier)
+      (integer_literal)
+      (integer_literal))
+    (list
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))))
+
+================================================================================
 Let local variable
 ================================================================================
 


### PR DESCRIPTION
As seen in the new htmlfold.vim Vim script:

    let names[: idx] = repeat([''], (idx + 1))