### PR TITLE
fix(node): add binding.gyp for native grammar builds

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,17 @@
+{
+  'targets': [
+    {
+      'target_name': 'tree_sitter_vim',
+      'include_dirs': [
+        'src',
+      ],
+      'sources': [
+        'src/parser.c',
+        'src/scanner.c',
+      ],
+      'cflags_c': [
+        '-std=c11',
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
This repository ships generated C sources in `src/`, and `package.json` still lists `binding.gyp` in `files`, but the file is missing from the repository and release tarballs.

Some downstream build systems derive the native grammar compile command from `binding.gyp`. Without it, packaging fails even though `src/parser.c` and `src/scanner.c` are present and sufficient to build the shared grammar library.

This patch adds a minimal `binding.gyp` describing the shipped C sources.

If `binding.gyp` is no longer intended to be supported, then `package.json` likely needs a cleanup instead to remove the stale reference.