### PR TITLE
fix for variable shadowing detected by lazyvim installer in scanner.c

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -278,8 +278,8 @@ static bool try_lex_keyword(char *possible, keyword keyword) {
 
   size_t mandat_len = i;
   // Now try lexing optional part
-  for (size_t i = 0; keyword.opt[i] && possible[mandat_len + i]; i++) {
-    if (possible[mandat_len + i] != keyword.opt[i]) {
+  for (size_t j = 0; keyword.opt[j] && possible[mandat_len + j]; j++) {
+    if (possible[mandat_len + j] != keyword.opt[j]) {
       return false;
     }
   }


### PR DESCRIPTION
This PR proposes a fix that resolves variable shadowing in the try_lex_keyword function in scanner.c

The reason for this is that nvim-treesitter compiles with -Werror -Wshadow, and so the shadowing was seen as an error by the compiler.

The fix is just to rename 'i' with 'j' in a for loop in line 281 and inside the loop body.

Tested by compiling src/scanner.c with clang -Werror -Wshadow before and after the fix.